### PR TITLE
Bump docker images, change service types and change Jupyter command

### DIFF
--- a/rapidsai/requirements.lock
+++ b/rapidsai/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: dask
   repository: https://helm.dask.org/
-  version: 4.1.4
-digest: sha256:6ac33649805b8d7e59814d480e24b3c3e756e27f02162c41ed3d527513818962
-generated: "2020-01-30T10:01:46.258427Z"
+  version: 4.2.0
+digest: sha256:b8312b8d32e2087d2bf639c6a60eafa2386b8410abb43dd07f6e452f1ddb473f
+generated: "2020-08-04T14:03:56.43561+01:00"

--- a/rapidsai/requirements.yaml
+++ b/rapidsai/requirements.yaml
@@ -1,5 +1,5 @@
 # requirements.yaml
 dependencies:
 - name: dask
-  version: "4.1.4"
+  version: "4.2.0"
   repository: 'https://helm.dask.org/'

--- a/rapidsai/templates/NOTES.txt
+++ b/rapidsai/templates/NOTES.txt
@@ -15,13 +15,13 @@ cluster. You can get these addresses by running the following:
 
   export DASK_SCHEDULER=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath='{.items[0].status.addresses[0].address}')
   export DASK_SCHEDULER_UI_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath='{.items[0].status.addresses[0].address}')
-  export DASK_SCHEDULER_PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "dask.fullname" . }}-scheduler -o jsonpath='{.spec.ports[?(@.name=="{{ template "dask.fullname" . }}-{{ .Values.dask.scheduler.name }}")].nodePort}')
-  export DASK_SCHEDULER_UI_PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "dask.fullname" . }}-scheduler -o jsonpath='{.spec.ports[?(@.name=="{{ template "dask.fullname" . }}-{{ .Values.dask.webUI.name }}")].nodePort}')
+  export DASK_SCHEDULER_PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ .Values.dask.fullnameOverride }}-scheduler -o jsonpath='{.spec.ports[?(@.name=="{{ .Values.dask.fullnameOverride }}-{{ .Values.dask.scheduler.name }}")].nodePort}')
+  export DASK_SCHEDULER_UI_PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ .Values.dask.fullnameOverride }}-scheduler -o jsonpath='{.spec.ports[?(@.name=="{{ .Values.dask.fullnameOverride }}-{{ .Values.dask.webUI.name }}")].nodePort}')
 
 {{- else if contains "LoadBalancer" .Values.dask.scheduler.serviceType }}
 
-  export DASK_SCHEDULER=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "dask.fullname" . }}-scheduler -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  export DASK_SCHEDULER_UI_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "dask.fullname" . }}-scheduler -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  export DASK_SCHEDULER=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ .Values.dask.fullnameOverride }}-scheduler -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  export DASK_SCHEDULER_UI_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ .Values.dask.fullnameOverride }}-scheduler -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   export DASK_SCHEDULER_PORT={{ .Values.dask.scheduler.servicePort }}
   export DASK_SCHEDULER_UI_PORT={{ .Values.dask.webUI.servicePort }}
 
@@ -31,8 +31,8 @@ cluster. You can get these addresses by running the following:
   export DASK_SCHEDULER_UI_IP="127.0.0.1"
   export DASK_SCHEDULER_PORT=8080
   export DASK_SCHEDULER_UI_PORT=8081
-  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "dask.fullname" . }}-scheduler $DASK_SCHEDULER_PORT:{{ .Values.dask.scheduler.servicePort }} &
-  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "dask.fullname" . }}-scheduler $DASK_SCHEDULER_UI_PORT:{{ .Values.dask.webUI.servicePort }} &
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ .Values.dask.fullnameOverride }}-scheduler $DASK_SCHEDULER_PORT:{{ .Values.dask.scheduler.servicePort }} &
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ .Values.dask.fullnameOverride }}-scheduler $DASK_SCHEDULER_UI_PORT:{{ .Values.dask.webUI.servicePort }} &
 
 {{- end }}
 
@@ -40,18 +40,18 @@ cluster. You can get these addresses by running the following:
 {{- if contains "NodePort" .Values.dask.jupyter.serviceType }}
 
   export JUPYTER_NOTEBOOK_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath='{.items[0].status.addresses[0].address}')
-  export JUPYTER_NOTEBOOK_PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "dask.fullname" . }}-jupyter -o jsonpath='{.spec.ports[0].nodePort}')
+  export JUPYTER_NOTEBOOK_PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ .Values.dask.fullnameOverride }}-jupyter -o jsonpath='{.spec.ports[0].nodePort}')
 
 {{- else if contains "LoadBalancer" .Values.dask.jupyter.serviceType }}
 
-  export JUPYTER_NOTEBOOK_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "dask.fullname" . }}-jupyter -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  export JUPYTER_NOTEBOOK_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ .Values.dask.fullnameOverride }}-jupyter -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   export JUPYTER_NOTEBOOK_PORT={{ .Values.dask.jupyter.servicePort }}
 
 {{- else if contains "ClusterIP"  .Values.dask.jupyter.serviceType }}
 
   export JUPYTER_NOTEBOOK_IP="127.0.0.1"
   export JUPYTER_NOTEBOOK_PORT=8082
-  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "dask.fullname" . }}-jupyter $JUPYTER_NOTEBOOK_PORT:{{ .Values.dask.jupyter.servicePort }} &
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ .Values.dask.fullnameOverride }}-jupyter $JUPYTER_NOTEBOOK_PORT:{{ .Values.dask.jupyter.servicePort }} &
 
 {{- end }}
 
@@ -60,6 +60,6 @@ cluster. You can get these addresses by running the following:
   echo http://$JUPYTER_NOTEBOOK_IP:$JUPYTER_NOTEBOOK_PORT       -- Jupyter notebook
 
 NOTE: It may take a few minutes for the LoadBalancer IP to be available. Until then, the commands above will not work for the LoadBalancer service type.
-You can watch the status by running 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "dask.fullname" . }}-scheduler'
+You can watch the status by running 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ .Values.dask.fullnameOverride }}-scheduler'
 
 NOTE: The default password to login to the notebook server is `rapidsai`. To change this password, refer to the Jupyter password section in values.yaml, or in the README.md.

--- a/rapidsai/values.yaml
+++ b/rapidsai/values.yaml
@@ -6,15 +6,15 @@ dask:
     name: scheduler
     image:
       repository: "rapidsai/rapidsai"
-      tag: cuda10.0-runtime-ubuntu16.04
+      tag: 0.14-cuda10.1-runtime-ubuntu18.04-py3.7
       pullPolicy: IfNotPresent
       # See https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
       pullSecrets:
       #  - name: regcred
     replicas: 1
-    # serviceType: "ClusterIP"
+    serviceType: "ClusterIP"
     # serviceType: "NodePort"
-    serviceType: "LoadBalancer"
+    # serviceType: "LoadBalancer"
     servicePort: 8786
     resources: {}
     #  limits:
@@ -48,7 +48,7 @@ dask:
     name: worker
     image:
       repository: "rapidsai/rapidsai"
-      tag: cuda10.0-runtime-ubuntu16.04
+      tag: 0.14-cuda10.1-runtime-ubuntu18.04-py3.7
       pullPolicy: IfNotPresent
       dask_worker: "dask-cuda-worker"
       pullSecrets:
@@ -79,20 +79,21 @@ dask:
     enabled: true
     image:
       repository: "rapidsai/rapidsai"
-      tag: cuda10.0-runtime-ubuntu16.04
+      tag: 0.14-cuda10.1-runtime-ubuntu18.04-py3.7
       pullPolicy: IfNotPresent
       pullSecrets:
       #  - name: regcred
     replicas: 1
-    # serviceType: "ClusterIP"
+    serviceType: "ClusterIP"
     # serviceType: "NodePort"
-    serviceType: "LoadBalancer"
+    # serviceType: "LoadBalancer"
     servicePort: 80
     # This hash corresponds to the password 'rapidsai'
     password: 'sha1:56152965e045:3cd9a2065e78b4a4e46c2d6f35ddd0160fe5b94d'
+    command: ["/usr/bin/tini", "--", "bash"]
     args:
-      - bash
-      - '/rapids/notebooks/utils/start-jupyter.sh'
+      - "-c"
+      - "source /opt/conda/etc/profile.d/conda.sh && conda activate rapids && jupyter-lab --allow-root --ip=0.0.0.0 --no-browser --NotebookApp.token=''"
     extraConfig: |-
       c.ServerProxy.host_whitelist = ["localhost", "127.0.0.1", "rapidsai-scheduler"]
     env:


### PR DESCRIPTION
Things have a slipped a little out of sync with the upstream RAPIDS docker images and Dask helm chart. This PR pulls things back in line.

- Bump Dask chart dependency to 4.2.0.
- Bump RAPIDS docker images to 0.14.
- Fix name overrides in `NOTES.txt`. Example commands to access services should now work. Closes #9.
- Switch service default to `ClusterIP` to reflect Dask chart.
- Replace start Jupyter command with implicit starting of Jupyter Lab. Closes #1.
