### PR TITLE
 Runs Jupyter as a daemon service and updates dependency versions

### DIFF
--- a/rapidsai/requirements.lock
+++ b/rapidsai/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: dask
   repository: https://helm.dask.org/
-  version: 4.1.4
-digest: sha256:6ac33649805b8d7e59814d480e24b3c3e756e27f02162c41ed3d527513818962
-generated: "2020-01-30T10:01:46.258427Z"
+  version: 4.3.0
+digest: sha256:d1a3d2d279c44de5e2e802c5ec3563c5fc1330b1ba9dfe1bfc6d286dd935d680
+generated: "2020-08-11T10:43:35.287217+01:00"

--- a/rapidsai/requirements.lock
+++ b/rapidsai/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
-  - name: dask
-    repository: https://helm.dask.org/
-    version: 4.3.0
-digest: sha256:d1a3d2d279c44de5e2e802c5ec3563c5fc1330b1ba9dfe1bfc6d286dd935d680
-generated: "2020-08-11T10:43:35.287217+01:00"
+- name: dask
+  repository: https://helm.dask.org/
+  version: 4.5.0
+digest: sha256:c4d7b7b7619ff20ded8b333dc2046ce2dccebd3d58439ebc47bb78d8949b8753
+generated: "2020-09-15T10:09:52.544654+01:00"

--- a/rapidsai/requirements.yaml
+++ b/rapidsai/requirements.yaml
@@ -1,5 +1,5 @@
 # requirements.yaml
 dependencies:
 - name: dask
-  version: "4.3.0"
+  version: "4.5.0"
   repository: 'https://helm.dask.org/'

--- a/rapidsai/requirements.yaml
+++ b/rapidsai/requirements.yaml
@@ -1,5 +1,5 @@
 # requirements.yaml
 dependencies:
 - name: dask
-  version: "4.1.4"
+  version: "4.3.0"
   repository: 'https://helm.dask.org/'

--- a/rapidsai/values.yaml
+++ b/rapidsai/values.yaml
@@ -5,8 +5,8 @@ dask:
   scheduler:
     name: scheduler
     image:
-      repository: "rapidsai/rapidsai"
-      tag: cuda10.0-runtime-ubuntu16.04
+      repository: "rapidsai/rapidsai-nightly"
+      tag: 0.15-cuda10.1-runtime-ubuntu18.04
       pullPolicy: IfNotPresent
       # See https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
       pullSecrets:
@@ -47,8 +47,8 @@ dask:
   worker:
     name: worker
     image:
-      repository: "rapidsai/rapidsai"
-      tag: cuda10.0-runtime-ubuntu16.04
+      repository: "rapidsai/rapidsai-nightly"
+      tag: 0.15-cuda10.1-runtime-ubuntu18.04
       pullPolicy: IfNotPresent
       dask_worker: "dask-cuda-worker"
       pullSecrets:
@@ -78,8 +78,8 @@ dask:
     name: jupyter
     enabled: true
     image:
-      repository: "rapidsai/rapidsai"
-      tag: cuda10.0-runtime-ubuntu16.04
+      repository: "rapidsai/rapidsai-nightly"
+      tag: 0.15-cuda10.1-runtime-ubuntu18.04
       pullPolicy: IfNotPresent
       pullSecrets:
       #  - name: regcred
@@ -90,14 +90,16 @@ dask:
     servicePort: 80
     # This hash corresponds to the password 'rapidsai'
     password: 'sha1:56152965e045:3cd9a2065e78b4a4e46c2d6f35ddd0160fe5b94d'
-    args:
-      - bash
-      - '/rapids/notebooks/utils/start-jupyter.sh'
+    # args:
+    #   - bash
+    #   - '/rapids/notebooks/utils/start-jupyter.sh'
     extraConfig: |-
       c.ServerProxy.host_whitelist = ["localhost", "127.0.0.1", "rapidsai-scheduler"]
     env:
      - name: DASK_DISTRIBUTED__DASHBOARD__LINK
        value: /proxy/rapidsai-scheduler:8787/status
+     - name: JUPYTER_FG  # Run Jupyter as a daemon in the foreground
+       value: true
     resources:
       limits:
         cpu: 2

--- a/rapidsai/values.yaml
+++ b/rapidsai/values.yaml
@@ -6,7 +6,7 @@ dask:
     name: scheduler
     image:
       repository: "rapidsai/rapidsai"
-      tag: 0.14-cuda10.1-runtime-ubuntu18.04-py3.7
+      tag: 0.15-cuda10.1-runtime-ubuntu18.04
       pullPolicy: IfNotPresent
       # See https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
       pullSecrets:
@@ -48,7 +48,7 @@ dask:
     name: worker
     image:
       repository: "rapidsai/rapidsai"
-      tag: 0.14-cuda10.1-runtime-ubuntu18.04-py3.7
+      tag: 0.15-cuda10.1-runtime-ubuntu18.04
       pullPolicy: IfNotPresent
       dask_worker: "dask-cuda-worker"
       pullSecrets:
@@ -79,7 +79,7 @@ dask:
     enabled: true
     image:
       repository: "rapidsai/rapidsai"
-      tag: 0.14-cuda10.1-runtime-ubuntu18.04-py3.7
+      tag: 0.15-cuda10.1-runtime-ubuntu18.04
       pullPolicy: IfNotPresent
       pullSecrets:
       #  - name: regcred
@@ -90,16 +90,13 @@ dask:
     servicePort: 80
     # This hash corresponds to the password 'rapidsai'
     password: 'sha1:56152965e045:3cd9a2065e78b4a4e46c2d6f35ddd0160fe5b94d'
-    # args:
-    #   - bash
-    #   - '/rapids/notebooks/utils/start-jupyter.sh'
     extraConfig: |-
       c.ServerProxy.host_whitelist = ["localhost", "127.0.0.1", "rapidsai-scheduler"]
     env:
      - name: DASK_DISTRIBUTED__DASHBOARD__LINK
        value: /proxy/rapidsai-scheduler:8787/status
      - name: JUPYTER_FG  # Run Jupyter as a daemon in the foreground
-       value: true
+       value: "true"
     resources:
       limits:
         cpu: 2


### PR DESCRIPTION
As of RAPIDS 0.15 it is possible to run Jupyter in the foreground, avoiding duplicate Jupyter instances from starting.

This PR also bumps the Dask chart dependency to `4.5.0`.

Replaces #14