### PR TITLE
Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+> ⚠️ This Helm Chart has been deprecated. Please use the [Dask Helm Chart](https://helm.dask.org/) instead.
 
 Rapidsai
 ===========


### PR DESCRIPTION
Closes #21.

This chart should no longer be used and the Dask one should be used instead. Once the new deployment documentation is released with a guide on using the Dask chart with RAPIDS this link should be updated and then this whole repo should be archived.