### PR TITLE
Change deprecation link to RAPIDS docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> ⚠️ This Helm Chart has been deprecated. Please use the [Dask Helm Chart](https://helm.dask.org/) instead.
+> ⚠️ This Helm Chart has been deprecated. Please use the [Dask Helm Chart](https://docs.rapids.ai/deployment/stable/platforms/kubernetes.html#helm-chart) instead.
 
 Rapidsai
 ===========


### PR DESCRIPTION
Instead of directing to the Dask Helm Chart directing folks to the RAPIDS Deployment docs. This makes things easier to update in the future.